### PR TITLE
add support for a default sort order configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,12 @@ AjaxDatatablesRails.configure do |config|
 
   # available options for paginator are: :simple_paginator, :kaminari, :will_paginate
   # config.paginator = :simple_paginator
+
+  # available options depend on your database and tables, if the column doesn't exist
+  # on a specified table, this option will be ignored; specify this option as a string
+  # in the form of 'column_name.direction' -- if the direction is left off, 'asc' is
+  # assumed
+  # config.default_additional_sort = 'id.asc'
 end
 ```
 

--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -50,6 +50,7 @@ module AjaxDatatablesRails
       records = fetch_records
       records = filter_records(records) if params[:search].present?
       records = sort_records(records) if params[:order].present?
+      records = default_additional_sort(records)
       records = paginate_records(records) unless params[:length].present? && params[:length] == '-1'
       records
     end
@@ -66,6 +67,10 @@ module AjaxDatatablesRails
     end
 
     def filter_records(records)
+      fail orm_extension_error_text
+    end
+
+    def default_additional_sort(records)
       fail orm_extension_error_text
     end
 

--- a/lib/ajax-datatables-rails/config.rb
+++ b/lib/ajax-datatables-rails/config.rb
@@ -20,5 +20,6 @@ module AjaxDatatablesRails
 
     config_accessor(:orm) { :active_record }
     config_accessor(:db_adapter) { :pg }
+    config_accessor(:default_additional_sort) { nil }
   end
 end

--- a/lib/ajax-datatables-rails/orm/active_record.rb
+++ b/lib/ajax-datatables-rails/orm/active_record.rb
@@ -187,6 +187,22 @@ module AjaxDatatablesRails
         options = %w(desc asc)
         options.include?(item[:dir]) ? item[:dir].upcase : 'ASC'
       end
+
+      def default_additional_sort(records)
+        if config.default_additional_sort
+          config.default_additional_sort.split(',').inject(records) do |sorted, column_spec|
+            column_name, order = column_spec.split('.')
+            order ||= 'ASC'
+            if sorted.column_names.include?(column_name)
+              sorted.order(column_name.to_sym => order)
+            else
+              sorted
+            end
+          end
+        else
+          records
+        end
+      end
     end
   end
 end

--- a/lib/generators/datatable/templates/ajax_datatables_rails_config.rb
+++ b/lib/generators/datatable/templates/ajax_datatables_rails_config.rb
@@ -4,4 +4,10 @@ AjaxDatatablesRails.configure do |config|
 
   # available options for paginator are: :simple_paginator, :kaminari, :will_paginate
   # config.paginator = :simple_paginator
+
+  # available options depend on your database and tables, if the column doesn't exist
+  # on a specified table, this option will be ignored; specify this option as a string
+  # in the form of 'column_name.direction' -- if the direction is left off, 'asc' is
+  # assumed
+  # config.default_additional_sort = 'id.asc'
 end

--- a/spec/ajax-datatables-rails/configuration_spec.rb
+++ b/spec/ajax-datatables-rails/configuration_spec.rb
@@ -12,6 +12,10 @@ describe AjaxDatatablesRails do
       it "should have custom value" do
         expect(AjaxDatatablesRails.config.db_adapter).to eq(:mysql)
       end
+
+      it "should default the additional sort to nil" do
+        expect(AjaxDatatablesRails.config.default_additional_sort).to be_nil
+      end
     end
   end
 end

--- a/spec/ajax-datatables-rails/orm/active_record_filter_records_spec.rb
+++ b/spec/ajax-datatables-rails/orm/active_record_filter_records_spec.rb
@@ -5,11 +5,6 @@ describe 'AjaxDatatablesRails::ORM::ActiveRecord#filter_records' do
   let(:datatable) { SampleDatatable.new(view) }
 
   before(:each) do
-    AjaxDatatablesRails.configure do |config|
-      config.db_adapter = :sqlite
-      config.orm = :active_record
-    end
-
     User.create(username: 'johndoe', email: 'johndoe@example.com')
     User.create(username: 'msmith', email: 'mary.smith@example.com')
   end

--- a/spec/ajax-datatables-rails/orm/active_record_paginate_records_spec.rb
+++ b/spec/ajax-datatables-rails/orm/active_record_paginate_records_spec.rb
@@ -5,11 +5,6 @@ describe 'AjaxDatatablesRails::ORM::ActiveRecord#paginate_records' do
   let(:datatable) { SampleDatatable.new(view) }
 
   before(:each) do
-    AjaxDatatablesRails.configure do |config|
-      config.db_adapter = :sqlite
-      config.orm = :active_record
-    end
-
     User.create(username: 'johndoe', email: 'johndoe@example.com')
     User.create(username: 'msmith', email: 'mary.smith@example.com')
   end

--- a/spec/ajax-datatables-rails/orm/active_record_sort_records_spec.rb
+++ b/spec/ajax-datatables-rails/orm/active_record_sort_records_spec.rb
@@ -5,13 +5,7 @@ describe 'AjaxDatatablesRails::ORM::ActiveRecord#sort_records' do
   let(:datatable) { SampleDatatable.new(view) }
 
   before(:each) do
-    AjaxDatatablesRails.configure do |config|
-      config.db_adapter = :sqlite
-      config.orm = :active_record
-    end
-
-    User.create(username: 'johndoe', email: 'johndoe@example.com')
-    User.create(username: 'msmith', email: 'mary.smith@example.com')
+    create_many_sample_users
   end
 
   after(:each) do
@@ -24,8 +18,8 @@ describe 'AjaxDatatablesRails::ORM::ActiveRecord#sort_records' do
     it 'returns a records collection sorted by :order params' do
       # set to order Users by email in descending order
       datatable.params[:order]['0'] = { column: '1', dir: 'desc' }
-      expect(datatable.send(:sort_records, records).map(&:email)).to match(
-        ['mary.smith@example.com', 'johndoe@example.com']
+      expect(datatable.send(:sort_records, records).limit(2).map(&:email)).to match(
+        ["msmith49@example.com", "msmith47@example.com"]
       )
     end
 

--- a/spec/ajax-datatables-rails/orm/active_record_spec.rb
+++ b/spec/ajax-datatables-rails/orm/active_record_spec.rb
@@ -6,11 +6,6 @@ describe 'AjaxDatatablesRails::ORM::ActiveRecord#fetch_records' do
     let(:datatable) { SampleDatatable.new(view) }
 
     before(:each) do
-      AjaxDatatablesRails.configure do |config|
-        config.db_adapter = :sqlite
-        config.orm = :active_record
-      end
-
       User.create(username: 'johndoe', email: 'johndoe@example.com')
       User.create(username: 'msmith', email: 'mary.smith@example.com')
     end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -6,8 +6,10 @@ ActiveRecord::Schema.define do
     t.string :email
     t.string :first_name
     t.string :last_name
+    t.integer :an_int
+    t.string :column_with_single_value
 
-    t.timestamps
+    t.timestamps null: false
   end
 
   create_table :addresses, :force => true do |t|
@@ -18,26 +20,26 @@ ActiveRecord::Schema.define do
     t.string :state
     t.string :country
 
-    t.timestamps
+    t.timestamps null: false
   end
 
   create_table :purchased_orders, :force => true do |t|
     t.string :foo
     t.string :bar
 
-    t.timestamps
+    t.timestamps null: false
   end
 
   create_table :statistics_requests, :force => true do |t|
     t.string :baz
 
-    t.timestamps
+    t.timestamps null: false
   end
 
   create_table :statistics_sessions, :force => true do |t|
     t.string :foo
     t.integer :bar
 
-    t.timestamps
+    t.timestamps null: false
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,3 +8,17 @@ ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:"
 load File.dirname(__FILE__) + '/schema.rb'
 load File.dirname(__FILE__) + '/test_helpers.rb'
 require File.dirname(__FILE__) + '/test_models.rb'
+
+RSpec.configure do |config|
+  config.before(:each) do |_|
+    AjaxDatatablesRails.configure do |config|
+      config.db_adapter = :sqlite
+      config.orm = :active_record
+      config.default_additional_sort = nil
+    end
+  end
+
+  config.after(:each) do |_|
+    User.destroy_all
+  end
+end

--- a/spec/test_helpers.rb
+++ b/spec/test_helpers.rb
@@ -27,6 +27,12 @@ def sample_params
             "value"=>"", "regex"=>"false"
           }
         },
+        "4"=> {
+          "data"=>"4", "name"=>"", "searchable"=>"false", "orderable"=>"true",
+          "search"=> {
+            "value"=>"", "regex"=>"false"
+          }
+        }
       },
       "order"=> {
         "0"=> {"column"=>"0", "dir"=>"asc"}
@@ -39,10 +45,20 @@ def sample_params
   )
 end
 
+def create_many_sample_users
+  50.times.map do |n|
+    username = n % 2 == 0         \
+      ? "johndoe#{ "%02d" % n }"  \
+      : "msmith#{ "%02d" % n }"
+    email = "#{username}@example.com"
+    User.new(username: username, email: email, column_with_single_value: '000000|TBD', an_int: n)
+  end.shuffle.each(&:save!)
+end
+
 class SampleDatatable < AjaxDatatablesRails::Base
   def view_columns
     @view_columns ||= [
-      'User.username', 'User.email', 'User.first_name', 'User.last_name'
+      'User.username', 'User.email', 'User.first_name', 'User.last_name', 'User.column_with_single_value'
     ]
   end
 
@@ -53,4 +69,8 @@ class SampleDatatable < AjaxDatatablesRails::Base
   def get_raw_records
     User.all
   end
+end
+
+class ActiveRecordSampleDatatable < SampleDatatable
+  include AjaxDatatablesRails::ORM::ActiveRecord
 end


### PR DESCRIPTION
Postgres doesn't guarantee the order in which records return from the database, and when you end up sorting on a field wherein the records all have the same value, the order you get back from the database is not always stable.

According to [Postgres' documentation](http://www.postgresql.org/docs/9.4/static/queries-order.html)

> After a query has produced an output table (after the select list has been processed) it can optionally be sorted. If sorting is not chosen, the rows will be returned in an unspecified order. The actual order in that case will depend on the scan and join plan types and the order on disk, but it must not be relied on. A particular output ordering can only be guaranteed if the sort step is explicitly chosen.

This PR adds support for specifying a default sort order when none is selected, or in order to _tack onto_ a given sort for any reason.
